### PR TITLE
Start pool before deletion if it is inactive

### DIFF
--- a/scripts/helper/kvm/virsh-cleanup.sh
+++ b/scripts/helper/kvm/virsh-cleanup.sh
@@ -22,6 +22,12 @@ declare -i nvols
 pools=$(virsh pool-list --all | grep test-ocp | awk '{print $1}')
 for i in $pools
 do
+	pool_status=$(virsh pool-info $i | grep State | awk '{ print $2 }')
+	if [[ "$pool_status" == "inactive" ]]; then
+		echo "virsh pool-start $i"
+		virsh pool-start $i
+	fi
+
 	nvols=$(virsh vol-list $i | wc -l)-3
 	while :
 	do


### PR DESCRIPTION
The steps in "Delete storage volumes" loop requires the storage pool to be active. Added code for the same.